### PR TITLE
Make mutual TLS configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,7 @@ consul_upstart_start_on: start on runlevel [345]
 consul_upstart_stop_on: stop on runlevel [!345]
 
 consul_is_server: false
+consul_mutual_tls: true
 
 consul_domain: consul.
 

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -88,7 +88,6 @@
   "cert_file": "{{ consul_cert_file }}",
   "key_file": "{{ consul_key_file }}",
   "ca_file": "{{ consul_ca_file }}",
-  "verify_incoming": true,
   "verify_outgoing": true,
   "verify_server_hostname": {{ consul_verify_server_hostname|lower }},
 {% endif %}
@@ -97,6 +96,9 @@
   "key_file": "{{ consul_key_file }}",
   "ca_file": "{{ consul_ca_file }}",
   "verify_outgoing": true,
+{% endif %}
+{% if consul_mutual_tls and consul_ca_file is defined %}
+  "verify_incoming": true,
 {% endif %}
   "ports": {
     "dns": {{ consul_port_dns }},


### PR DESCRIPTION
`verify_incoming` should only be set to true if clients have valid TLS
configurations. Additionally, it only makes sense if they have
_independent_ TLS configurations with host-specific TLS certs. Enabling
mutual TLS just because TLS is enabled is restrictive in environments
that don't have the appropriate infrastructure for issuing those
independent certs.